### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking (CSWSH) vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-27 - [CSWSH Protection]
+**Vulnerability:** Local WebSocket IPC server allowed connections from any origin, making it vulnerable to Cross-Site WebSocket Hijacking (CSWSH) from malicious websites.
+**Learning:** Browsers automatically attach the Origin header to cross-origin WebSocket requests.
+**Prevention:** Rejecting incoming WebSocket connections that contain an Origin header prevents browsers from interacting with the local IPC server.

--- a/packages/wm/src/ipc_server.rs
+++ b/packages/wm/src/ipc_server.rs
@@ -8,7 +8,13 @@ use tokio::{
   sync::{broadcast, mpsc},
   task,
 };
-use tokio_tungstenite::{accept_async, tungstenite::Message};
+use tokio_tungstenite::{
+  accept_hdr_async,
+  tungstenite::{
+    handshake::server::{ErrorResponse, Request, Response},
+    Message,
+  },
+};
 use tracing::{info, warn};
 use uuid::Uuid;
 use wm_common::{
@@ -85,9 +91,28 @@ impl IpcServer {
   ) -> anyhow::Result<()> {
     info!("Incoming IPC connection from: {}.", addr);
 
-    let ws_stream = accept_async(stream)
-      .await
-      .context("Error during websocket handshake.")?;
+    let ws_stream = accept_hdr_async(
+      stream,
+      |req: &Request,
+       response: Response|
+       -> Result<Response, ErrorResponse> {
+        // The IPC server does not currently allow requests from browsers.
+        // We can enforce this by checking whether the request has
+        // an `Origin` header, which browsers are required to send.
+        if req.headers().get("origin").is_some() {
+          let err_response = Response::builder()
+            .status(403)
+            .body(Some("Forbidden".to_string().into()))
+            .unwrap();
+
+          return Err(err_response);
+        }
+
+        Ok(response)
+      },
+    )
+    .await
+    .context("Error during websocket handshake.")?;
 
     let (mut outgoing, mut incoming) = ws_stream.split();
     let (response_tx, mut response_rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
## **User description**
🚨 Severity: HIGH
💡 Vulnerability: The local IPC server allowed WebSocket connections from any origin, which could be abused by malicious websites via CSWSH.
🎯 Impact: A malicious website could connect to the local IPC server and send commands or receive sensitive information.
🔧 Fix: Updated the WebSocket handshake to reject incoming connections that contain an `Origin` header, which browsers automatically attach to cross-origin requests.
✅ Verification: Ensure the IPC server rejects WebSocket connections with an `Origin` header.

---
*PR created automatically by Jules for task [6011531967183125073](https://jules.google.com/task/6011531967183125073) started by @partrita*

## Summary by Sourcery

Enforce origin-based access control on the local WebSocket IPC server to mitigate CSWSH risk and document the security change.

Bug Fixes:
- Reject WebSocket IPC connections that include an Origin header to prevent cross-site WebSocket hijacking from browsers.

Documentation:
- Add Sentinel security note documenting the CSWSH vulnerability, browser Origin behavior, and the chosen mitigation strategy.


___

## **CodeAnt-AI Description**
**Block browser-based WebSocket access to the local IPC server**

### What Changed
- The local IPC server now rejects WebSocket connections that include an `Origin` header, which stops browser-based cross-site requests from reaching it.
- Connections without an `Origin` header can still connect as before.
- Added a security note explaining the risk and why this protection is in place.

### Impact
`✅ Fewer cross-site WebSocket attacks`
`✅ Safer local IPC access`
`✅ Clearer security guidance`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security for WebSocket connections by implementing origin header validation to prevent unauthorized cross-origin connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->